### PR TITLE
Use --fast instead of --relaxed

### DIFF
--- a/src/datalad_cds/download_cds.py
+++ b/src/datalad_cds/download_cds.py
@@ -88,7 +88,7 @@ class DownloadCDS(Interface):
         url = parsed_spec.to_url()
         options = []
         if lazy:
-            options.append("--relaxed")
+            options.append("--fast")
         ds.repo.add_url_to_file(pathobj, url, options=options)
         if save:
             msg = (


### PR DESCRIPTION
This change is in anticipation of the VURL backend and the --verifiable option of git annex addurl, which would allow automatic checksum verification for every download after the first one, without needing a backend migration. The documentation of --verifiable states that it will only verify subsequent downloads against the recorded checksum when used with --fast, while a combination with --relaxed would always accept the content it gets from the web / special remote.