### PR TITLE
Set allow-unverified-downloads in initremote

### DIFF
--- a/src/datalad_cds/cds_remote.py
+++ b/src/datalad_cds/cds_remote.py
@@ -14,7 +14,21 @@ class CDSRemote(SpecialRemote):
     remove = None
 
     def initremote(self) -> None:
-        pass
+        # Setting this here feels a bit rude, but we know that what we download is at
+        # least verified by a TLS certificate of the CDS, so this security issue doesn't
+        # affect the CDS special remote.
+        result = subprocess.run(
+            [
+                "git",
+                "config",
+                "remote.cds.annex-security-allow-unverified-downloads",
+                "ACKTHPPT",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RemoteError("unable to set necessary git config")
 
     def prepare(self) -> None:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,10 +33,4 @@ def single_file_dataset(request: SubRequest, empty_dataset: da.Dataset) -> da.Da
         lazy=request.param == "lazy",
         path="download.grib",
     )
-    if request.param == "lazy":
-        dataset.configuration(
-            "set",
-            [("remote.cds.annex-security-allow-unverified-downloads", "ACKTHPPT")],
-            scope="local",
-        )
     return dataset


### PR DESCRIPTION
This config setting is meant to protect against downloads from sources that can potentially be spoofed, e.g. private IP addresses which could be assigned to different machines on different networks. We know that this isn't the case for the CDS remote: the target for requests is always determined by the cdsapi package, which in turn talks to the CDS service and does TLS verification due to using HTTPS.

This means that we are unaffected by the security issue the setting is meant to protect against. So there is no need for a user of the CDS special remote to manually set the option in every repository, we might as well do it for them.