### PR TITLE
Do not auto-enable the cds remote

### DIFF
--- a/src/datalad_cds/download_cds.py
+++ b/src/datalad_cds/download_cds.py
@@ -128,7 +128,6 @@ def ensure_special_remote_exists_and_is_enabled(
             [
                 "encryption=none",
                 "type=external",
-                "autoenable=true",
                 "externaltype={}".format(remote),
                 "uuid={}".format(uuid),
             ],


### PR DESCRIPTION
It seems more likely than not that people don't have datalad-cds installed at the time of cloning a dataset. Thus, auto-enabling leads to some potentially confusing error messages and then leaves the repository in a state in which the remote is disabled. The message when cloning a repository with a not-auto-enabling cds remote is more appropriate, I think.